### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/application/geomajas-gwt-example/pom.xml
+++ b/application/geomajas-gwt-example/pom.xml
@@ -161,7 +161,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>xpp3</groupId>

--- a/plugin/geomajas-layer-geotools/pom.xml
+++ b/plugin/geomajas-layer-geotools/pom.xml
@@ -100,7 +100,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/plugin/geomajas-plugin-deskmanager/pom.xml
+++ b/plugin/geomajas-plugin-deskmanager/pom.xml
@@ -241,7 +241,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>xml-apis</groupId>

--- a/plugin/geomajas-plugin-printing/pom.xml
+++ b/plugin/geomajas-plugin-printing/pom.xml
@@ -163,7 +163,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			
 			<dependency>

--- a/plugin/geomajas-plugin-rasterizing/pom.xml
+++ b/plugin/geomajas-plugin-rasterizing/pom.xml
@@ -129,7 +129,7 @@
  			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
    			<dependency>
 				<groupId>commons-codec</groupId>

--- a/plugin/geomajas-plugin-staticsecurity/pom.xml
+++ b/plugin/geomajas-plugin-staticsecurity/pom.xml
@@ -115,7 +115,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents</groupId>

--- a/plugin/geomajas-plugin-vendorspecificpipeline/pom.xml
+++ b/plugin/geomajas-plugin-vendorspecificpipeline/pom.xml
@@ -121,7 +121,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/project/geomajas-project-sld-editor/expert-gwt-example-jar/pom.xml
+++ b/project/geomajas-project-sld-editor/expert-gwt-example-jar/pom.xml
@@ -61,7 +61,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/project/geomajas-project-sld-editor/expert-gwt-example/pom.xml
+++ b/project/geomajas-project-sld-editor/expert-gwt-example/pom.xml
@@ -63,7 +63,7 @@
 			<dependency>
 				<groupId>commons-collections</groupId>
 				<artifactId>commons-collections</artifactId>
-				<version>3.2.1</version>
+				<version>3.2.2</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
